### PR TITLE
Changed X-XSS-Protection to follow OWASP standards due to deprecation.

### DIFF
--- a/src/main/java/com/endava/cats/fuzzer/headers/CheckSecurityHeadersFuzzer.java
+++ b/src/main/java/com/endava/cats/fuzzer/headers/CheckSecurityHeadersFuzzer.java
@@ -32,7 +32,7 @@ public class CheckSecurityHeadersFuzzer implements Fuzzer {
     private static final List<CatsHeader> SECURITY_HEADERS = Arrays.asList(CatsHeader.builder().name("Cache-Control").value("no-store").build(),
             CatsHeader.builder().name("X-Content-Type-Options").value("nosniff").build(),
             CatsHeader.builder().name("X-Frame-Options").value("DENY").build(),
-            CatsHeader.builder().name("X-XSS-Protection").value("1; mode=block").build());
+            CatsHeader.builder().name("X-XSS-Protection").value("0").build());
 
     protected static final String SECURITY_HEADERS_AS_STRING = SECURITY_HEADERS.stream().map(CatsHeader::nameAndValue).collect(Collectors.toSet()).toString();
 

--- a/src/test/java/com/endava/cats/fuzzer/headers/CheckSecurityHeadersFuzzerTest.java
+++ b/src/test/java/com/endava/cats/fuzzer/headers/CheckSecurityHeadersFuzzerTest.java
@@ -33,7 +33,7 @@ class CheckSecurityHeadersFuzzerTest {
     private static final List<CatsHeader> SOME_SECURITY_HEADERS = Arrays.asList(CatsHeader.builder().name("Cache-Control").value("no-store").build(),
             CatsHeader.builder().name("X-Content-Type-Options").value("nosniff").build());
     private static final List<CatsHeader> MISSING_HEADERS = Arrays.asList(CatsHeader.builder().name("X-Frame-Options").value("DENY").build(),
-            CatsHeader.builder().name("X-XSS-Protection").value("1; mode=block").build());
+            CatsHeader.builder().name("X-XSS-Protection").value("0").build());
     @Mock
     private ServiceCaller serviceCaller;
 


### PR DESCRIPTION
Modified the `CheckSecurityHeadersFuzzer.java` to check that `X-XSS-Protection` header is disabled in order to align with the OWASP standards. As most browser vendors have deprecated or removed this feature due to the fact it can introduce additional security issues.  Please view the following references:

**OWASP:**
![image](https://user-images.githubusercontent.com/3812154/124355183-d157b500-dc07-11eb-8ac2-2c513ff1ced1.png)

**Mozilla Developer Network Web Docs:**
![image](https://user-images.githubusercontent.com/3812154/124355214-f0564700-dc07-11eb-9113-63c064781597.png)

**References:**
OWASP - https://owasp.org/www-project-secure-headers/#x-xss-protection
MDN - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
