### PR TITLE
Fix oneOf payload sample bug

### DIFF
--- a/src/main/java/com/endava/cats/model/factory/FuzzingDataFactory.java
+++ b/src/main/java/com/endava/cats/model/factory/FuzzingDataFactory.java
@@ -331,7 +331,7 @@ public class FuzzingDataFactory {
             }
 
             //when a request has only oneOf or anyOf fields, there is no additional key to create this
-            if (newKey.equalsIgnoreCase("body")) {
+            if (newKey.toLowerCase().contains("body")) {
                 result.add(value.toString());
             } else {
                 jsonElement.getAsJsonObject().add(newKey, value);


### PR DESCRIPTION
This PR fixes a bug that wraps an unexpected object around `oneOf` payload samples.

Snippet of OpenAPI spec:
```
paths:
  /testpath:
    post:
      requestBody:
        content:
          application/json:
            schema:
              oneOf:
              - $ref: '#/components/schemas/Schema1'
              - $ref: '#/components/schemas/Schema2'
```

Actual payloads:
```
{
  "testpath_body": {
    <Schema1>
  }
}
```
```
{
  "testpath_body": {
    <Schema2>
  }
}
```

Expected payloads:
```
{
  <Schema1>
}
```
```
{
  <Schema2>
}
```