### PR TITLE
Regex gen fix

### DIFF
--- a/src/main/java/com/endava/cats/generator/simple/StringGenerator.java
+++ b/src/main/java/com/endava/cats/generator/simple/StringGenerator.java
@@ -121,6 +121,9 @@ public class StringGenerator {
         RegExpGen generator = REGEXPGEN_PROVIDER.matchingExact(pattern);
 
         for (int i = 0; i < MAX_ATTEMPTS_GENERATE; i++) {
+            if(min == max) {
+                min -= max;
+            }
             String generated = generator.generate(REGEXPGEN_RANDOM, min, max);
 
             if (generated.matches(pattern)) {

--- a/src/test/java/com/endava/cats/fuzzer/fields/ExactValuesInFieldsFuzzerTest.java
+++ b/src/test/java/com/endava/cats/fuzzer/fields/ExactValuesInFieldsFuzzerTest.java
@@ -46,6 +46,16 @@ class ExactValuesInFieldsFuzzerTest {
     }
 
     @Test
+    void shouldGetBoundaryValueForSchemaWithPatternUsingRegexGen() {
+        Schema<String> schema = new StringSchema();
+        schema.setPattern("^(A-\\d{1,12})$");
+        schema.setMaxLength(14);
+        String generated = myBaseBoundaryFuzzer.getBoundaryValue(schema);
+
+        Assertions.assertThat(generated).matches("^(A-\\d{1,12})$");
+    }
+
+    @Test
     void shouldGetNullBoundaryValueWhenNoBoundaries() {
         Schema<String> schema = new StringSchema();
         String generated = myBaseBoundaryFuzzer.getBoundaryValue(schema);


### PR DESCRIPTION
I had a weird Exception when using an openapi spec with a regex Pattern like this:
```
      pattern: "^(M-\\d{1,12})$"
      maxLength: 14
```
reproduced it with a test and found a solution which works for me.