### PR TITLE
Update TestCaseExporter.java

### DIFF
--- a/src/main/java/com/endava/cats/report/TestCaseExporter.java
+++ b/src/main/java/com/endava/cats/report/TestCaseExporter.java
@@ -318,6 +318,9 @@ public abstract class TestCaseExporter {
             logger.error("There was a problem writing test case {}: {}. Please check if CATS has proper right to write in the report location: {}",
                     testCase.getTestId(), e.getMessage(), reportingPath.toFile().getAbsolutePath());
             logger.debug(STACKTRACE, e);
+        } catch (NegativeArraySizeException e) {
+            logger.debug(e.getMessage());
+            logger.debug(STACKTRACE, e);
         }
     }
 


### PR DESCRIPTION
Catch NegativeArrayizeExcepetion.

I encountered a very confusing NegativeArraySizeException which is not catched by the IOException catch block.
Further I observed, that in rare cases the report creation does exceed the java heap size in which case the application crashes.
Did a bit of tweaking of the heapsize and garbage collector, but couldn't fix the heap exceeding.
I will do further investigations and provide some cases for reproduction by Time. For now catching the exception was the first step for not crashing at least...