### PR TITLE
The filtering predicate to filter fuzzerToRun is now working properly

### DIFF
--- a/src/main/java/com/endava/cats/command/CatsCommand.java
+++ b/src/main/java/com/endava/cats/command/CatsCommand.java
@@ -367,13 +367,10 @@ public class CatsCommand implements Runnable, CommandLine.IExitCodeGenerator {
 
         // excludes Fuzzers whose HTTP methods do not match the FuzzingData http method
         List<Fuzzer> fuzzersToRun = filterArguments.getFirstPhaseFuzzersAsFuzzers().stream()
-                .filter(fuzzer -> fuzzer.skipForHttpMethods()
+                .filter(fuzzer -> !(fuzzer.skipForHttpMethods().containsAll(filteredFuzzingData
                         .stream()
-                        .noneMatch(httpMethod -> filteredFuzzingData
-                                .stream()
-                                .map(FuzzingData::getMethod)
-                                .toList()
-                                .contains(httpMethod)))
+                        .map(FuzzingData::getMethod)
+                        .collect(Collectors.toList()))))
                 .toList();
 
         testCaseListener.setTotalRunsPerPath(pathItemEntry.getKey(), fuzzersToRun.size() * filteredFuzzingData.size());


### PR DESCRIPTION
**CATS Version: 10.3.0**

**What is the issue?**
POST request for one of the path is not getting fuzzed.

Spec file: 
[petstore-country-code.json](https://github.com/Endava/cats/files/14438878/petstore-country-code.json)

**Steps to reproduce the issue:**

1. Run the prism mock server with above spec file
2. From other machine run the CATS tool with one fuzzer: MaxLengthExactValuesInStringFieldsFuzzer
3. For /pets path there is POST method defined and in the "Pet" object there is "name" field with maxLength defined
4. So ideally, CATS should fuzz this object and send one request with POST method
5. But CATS will not send any request

**What is the root cause?**
This predicate to filter out fuzzerToRun is not working properly. If path have GET, DELETE and POST method, then this predicate
filters out fuzzers which are only applicable for POST, PUT, PATCH methods, for the current path.

**What is the fix?**
 I have added the fix by putting correct predicate logic. It is base on List.containsAll() method

Please review the fix and update if required 

