### PR TITLE
ExplainCommand: Sort by Fuzzer simple name

### DIFF
--- a/src/main/java/com/endava/cats/command/ExplainCommand.java
+++ b/src/main/java/com/endava/cats/command/ExplainCommand.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import picocli.CommandLine;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Locale;
 
 @CommandLine.Command(
@@ -72,7 +73,7 @@ public class ExplainCommand implements Runnable {
     private void displayFuzzerInfo() {
         fuzzers.stream().filter(fuzzer -> fuzzer.getClass().getSimpleName()
                         .toLowerCase(Locale.ROOT).contains(info.toLowerCase(Locale.ROOT)))
-                .sorted()
+                .sorted(Comparator.comparing(fuzzer -> fuzzer.getClass().getSimpleName()))
                 .forEach(fuzzer -> logger.noFormat("* Fuzzer {} - {}", fuzzer.getClass().getSimpleName(), fuzzer.description()));
     }
 


### PR DESCRIPTION
Sort fuzzers comparing their simple names. Fixes a crash when using Explain command and there are multiple matches.

Fuzzer is not a Comparable so sort() can't be used on a Stream of fuzzers. To fix the issue, we can add a Comparator or make Fuzzer a Comparable.

The issue can be reproduced using `java -jar ./target/cats-runner.jar explain --type=FUZZER fuzzer`, and this is the Exception thrown:
```
java.lang.ClassCastException: class com.endava.cats.fuzzer.http.CheckDeletedResourcesNotAvailableFuzzer cannot be cast to class java.lang.Comparable (com.endava.cats.fuzzer.http.CheckDeletedResourcesNotAvailableFuzzer is in unnamed module of loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap')
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:234)
	at java.base/java.util.Arrays.sort(Arrays.java:1308)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1804)
	at java.base/java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:392)
	at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at com.endava.cats.command.ExplainCommand.displayFuzzerInfo(ExplainCommand.java:76)
	at com.endava.cats.command.ExplainCommand.run(ExplainCommand.java:58)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2030)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at com.endava.cats.CatsMain.run(CatsMain.java:41)
	at com.endava.cats.CatsMain_ClientProxy.run(Unknown Source)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:143)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:77)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:48)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
```