### PR TITLE
fix: CLI --server parameter should take priority over OpenAPI servers

### DIFF
--- a/src/test/java/com/endava/cats/args/ApiArgumentsTest.java
+++ b/src/test/java/com/endava/cats/args/ApiArgumentsTest.java
@@ -99,6 +99,24 @@ class ApiArgumentsTest {
     }
 
     @Test
+    void shouldPreferCliServerOverOpenApiConcreteServer() {
+        CommandLine.Model.CommandSpec spec = Mockito.mock(CommandLine.Model.CommandSpec.class);
+        Mockito.when(spec.commandLine()).thenReturn(Mockito.mock(CommandLine.class));
+        ApiArguments args = new ApiArguments();
+        args.setServer("http://localhost:8080");
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setServers(Collections.singletonList(
+                new io.swagger.v3.oas.models.servers.Server().url("https://api.example.com")
+        ));
+
+        args.validateValidServer(spec, openAPI);
+
+        // CLI server should take priority over concrete OpenAPI server
+        Assertions.assertThat(args.getServer()).isEqualTo("http://localhost:8080");
+    }
+
+    @Test
     void shouldThrowExceptionWhenServerIsInvalidUrl() {
         CommandLine.Model.CommandSpec spec = Mockito.mock(CommandLine.Model.CommandSpec.class);
         Mockito.when(spec.commandLine()).thenReturn(Mockito.mock(CommandLine.class));


### PR DESCRIPTION
## Summary

Fixes a bug where the CLI `--server` parameter is ignored when the OpenAPI specification contains a concrete server URL.

## Problem

When a user provides both:
- CLI parameter: `--server=http://localhost:8080`
- OpenAPI spec with: `https://api.example.com`

**Current behavior (bug):** Uses `https://api.example.com` (CLI ignored)
**Expected behavior:** Uses `http://localhost:8080` (CLI takes priority)

The existing behavior works correctly for:
- Placeholder servers: `{apiRoot}/v2` - CLI replaces placeholder ✅
- Relative paths: `/api/v1` - CLI gets prepended ✅
- Concrete URLs: `https://api.example.com` - CLI ignored ❌ **BUG**

## Solution

Refactored `ApiArguments.validateValidServer()` to handle three scenarios:

1. **No CLI server provided**: Use OpenAPI server (existing behavior)
2. **CLI server + OpenAPI server with placeholders/relative paths**: Use OpenAPI server for variable replacement (existing behavior)
3. **CLI server + concrete OpenAPI URL**: Use CLI server (NEW - fixes the bug)

**File:** `src/main/java/com/endava/cats/args/ApiArguments.java`

**Changes:**
- Split logic into two branches based on whether CLI `--server` is provided
- When CLI server exists, check if OpenAPI server has placeholders (`{`) or relative paths (doesn't start with `http`)
- Concrete OpenAPI URLs no longer override CLI server parameter
- Improved debug logging

```diff
 if (openAPI != null) {
     List<String> servers = OpenApiServerExtractor.getServerUrls(openAPI);
-    log.debug("--server not provided. Loaded from OpenAPI: {}", servers);
-    servers.stream().findFirst().ifPresent(theServer -> this.server = theServer);
+    log.debug("Servers from OpenAPI: {}", servers);
+
+    if (serverFromInput == null) {
+        // No CLI server provided, use OpenAPI server
+        servers.stream().findFirst().ifPresent(theServer -> this.server = theServer);
+    } else {
+        // CLI server provided, check if OpenAPI server has placeholders or relative paths
+        servers.stream().findFirst().ifPresent(openApiServer -> {
+            if (openApiServer.contains("{") || !openApiServer.startsWith("http")) {
+                // OpenAPI server has placeholders or is relative, use it for replacement
+                this.server = openApiServer;
+            }
+            // Otherwise keep CLI server (concrete OpenAPI URLs don't override CLI)
+        });
+    }
 }
```

## Testing

Added regression test `shouldPreferCliServerOverOpenApiConcreteServer()` in `ApiArgumentsTest.java` to verify CLI server takes priority over concrete OpenAPI URLs.

### Behavior Matrix After Fix

| CLI Server | OpenAPI Server | Result | Status |
|------------|----------------|--------|---------|
| `http://localhost:8080` | `https://api.example.com` | `http://localhost:8080` | ✅ **FIXED** |
| `http://api.com` | `{apiRoot}/v2` | `http://api.com/v2` (via replacement) | Behavior unchanged |
| `http://api.com` | `/v1` | `/v1` (relative path used) | Behavior unchanged |
| `null` | `https://api.example.com` | `https://api.example.com` | Behavior unchanged |
| `null` | `null` | Error | Behavior unchanged |

## Files Changed
- `src/main/java/com/endava/cats/args/ApiArguments.java` - 17 lines added, 2 removed
- `src/test/java/com/endava/cats/args/ApiArgumentsTest.java` - 18 lines added (new test)

## Checklist

- [x] Added tests for the bug fix
- [x] Preserves all existing behavior for placeholders and relative paths
- [x] Follows IntelliJ IDEA coding style
- [x] Test suite passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>