### PR TITLE
fix: Prevent negative count in SimpleJsonFormatter

### DIFF
--- a/src/main/java/com/endava/cats/util/SimpleJsonFormatter.java
+++ b/src/main/java/com/endava/cats/util/SimpleJsonFormatter.java
@@ -54,7 +54,7 @@ public abstract class SimpleJsonFormatter {
                     }
                     case '}', ']' -> {
                         if (prevChar != '{' && prevChar != '[' && prevChar != '\n') {
-                            formatted.append('\n').append(indent.repeat(indentLevel - 1));
+                            formatted.append('\n').append(indent.repeat(Math.max(0, indentLevel - 1)));
                         }
                         indentLevel--;
                         formatted.append(currentChar);

--- a/src/test/java/com/endava/cats/util/SimpleJsonFormatterTest.java
+++ b/src/test/java/com/endava/cats/util/SimpleJsonFormatterTest.java
@@ -44,4 +44,27 @@ class SimpleJsonFormatterTest {
         String result = SimpleJsonFormatter.formatJson(input);
         assertThat(result).isEqualTo(expected);
     }
+
+    @Test
+    void shouldHandleMalformedJsonWithExtraClosingBrackets() {
+        String input = "{\"key\":\"value\"}}";
+        String result = SimpleJsonFormatter.formatJson(input);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void shouldHandleMalformedJsonWithExtraClosingSquareBrackets() {
+        String input = "[1,2,3]]";
+        String result = SimpleJsonFormatter.formatJson(input);
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void shouldHandleNestedStructures() {
+        String input = "{\"outer\":{\"inner\":{\"deep\":\"value\"}}}";
+        String result = SimpleJsonFormatter.formatJson(input);
+        assertThat(result).contains("\"outer\":");
+        assertThat(result).contains("\"inner\":");
+        assertThat(result).contains("\"deep\": \"value\"");
+    }
 }


### PR DESCRIPTION
## Summary
Fixes `IllegalArgumentException: count is negative: -1` that occurs when CATS generates HTML reports for API responses containing malformed JSON with extra closing brackets.

## Root Cause
The `SimpleJsonFormatter.formatJsonString()` method was calling `String.repeat(indentLevel - 1)` on line 57 without checking if `indentLevel` was 0, resulting in a negative repeat count.

This occurred when:
- API responses contained malformed JSON (e.g., `{"key":"value"}}`)
- The formatter encountered more closing brackets than opening brackets
- The `indentLevel` counter reached 0 before all closing brackets were processed

## Changes
- **Fix:** Added `Math.max(0, indentLevel - 1)` guard in [SimpleJsonFormatter.java:57](https://github.com/Endava/cats/blob/master/src/main/java/com/endava/cats/util/SimpleJsonFormatter.java#L57)
- **Tests:** Added 3 test cases for malformed JSON edge cases:
  - `shouldHandleMalformedJsonWithExtraClosingBrackets()` - tests `{...}}`
  - `shouldHandleMalformedJsonWithExtraClosingSquareBrackets()` - tests `[...]]`
  - `shouldHandleNestedStructures()` - ensures normal nested JSON still works

## Test Results
```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

All tests pass, including the 3 new edge case tests.

## Impact
- **Before:** CATS would crash with `MustacheException` when generating HTML reports for malformed JSON responses
- **After:** CATS gracefully handles malformed JSON and continues generating reports

## Files Changed
- `src/main/java/com/endava/cats/util/SimpleJsonFormatter.java` - 1 line changed
- `src/test/java/com/endava/cats/util/SimpleJsonFormatterTest.java` - 23 lines added

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>