### PR TITLE
Refactor: duplicated functions and optimization

### DIFF
--- a/src/main/java/com/endava/cats/args/ProcessingArguments.java
+++ b/src/main/java/com/endava/cats/args/ProcessingArguments.java
@@ -173,15 +173,23 @@ public class ProcessingArguments {
     }
 
     /**
+     * Resolves an example flag by returning the global {@code --useExamples} override when set,
+     * or the specific flag value otherwise.
+     *
+     * @param specificFlag the flag for a specific examples category
+     * @return the resolved boolean value
+     */
+    private boolean resolveFlag(boolean specificFlag) {
+        return useExamples != null ? useExamples : specificFlag;
+    }
+
+    /**
      * Returns if usage of request body examples is enabled. This applies for examples set at media-type level in the requestBody: element.
      *
      * @return true if usage of request body examples is enabled, false otherwise
      */
     public boolean isUseRequestBodyExamples() {
-        if (useExamples != null) {
-            return useExamples;
-        }
-        return useRequestBodyExamples;
+        return resolveFlag(useRequestBodyExamples);
     }
 
     /**
@@ -190,10 +198,7 @@ public class ProcessingArguments {
      * @return true if usage of response body examples is enabled, false otherwise
      */
     public boolean isUseResponseBodyExamples() {
-        if (useExamples != null) {
-            return useExamples;
-        }
-        return useResponseBodyExamples;
+        return resolveFlag(useResponseBodyExamples);
     }
 
     /**
@@ -202,10 +207,7 @@ public class ProcessingArguments {
      * @return true if usage of schema examples is enabled, false otherwise
      */
     public boolean isUseSchemaExamples() {
-        if (useExamples != null) {
-            return useExamples;
-        }
-        return useSchemaExamples;
+        return resolveFlag(useSchemaExamples);
     }
 
     /**
@@ -214,10 +216,7 @@ public class ProcessingArguments {
      * @return true if usage of property examples is enabled, false otherwise
      */
     public boolean isUsePropertyExamples() {
-        if (useExamples != null) {
-            return useExamples;
-        }
-        return usePropertyExamples;
+        return resolveFlag(usePropertyExamples);
     }
 
     /**


### PR DESCRIPTION
This pull request refactors how example-related flags are resolved in the `ProcessingArguments` class, improving code maintainability and consistency. The main change is the introduction of a new private method to centralize flag resolution logic, which is then used across multiple methods.

Flag resolution refactoring:

* Added a private `resolveFlag` method to handle the logic for resolving example flags, prioritizing the global `useExamples` override when set, or falling back to the specific flag value.
* Updated the `isUseRequestBodyExamples`, `isUseResponseBodyExamples`, `isUseSchemaExamples`, and `isUsePropertyExamples` methods to use the new `resolveFlag` method, reducing code duplication and ensuring consistent behavior. [[1]](diffhunk://#diff-d60080406856fea066e76d127841492a187c6be45aa92aee1920c9917fbd4180L193-R201) [[2]](diffhunk://#diff-d60080406856fea066e76d127841492a187c6be45aa92aee1920c9917fbd4180L205-R210) [[3]](diffhunk://#diff-d60080406856fea066e76d127841492a187c6be45aa92aee1920c9917fbd4180L217-R219)